### PR TITLE
expert_activation_profile: cross-architecture portability (OLMoE / Granite / DeepSeek)

### DIFF
--- a/scripts/expert_activation_profile.py
+++ b/scripts/expert_activation_profile.py
@@ -105,8 +105,27 @@ def main() -> int:
     model.eval()
     cfg = model.config
     num_layers = cfg.num_hidden_layers
-    num_experts = cfg.num_experts
-    num_experts_per_tok = cfg.num_experts_per_tok
+    # MoE field names vary across families: Qwen3MoE/Olmoe use num_experts,
+    # GraniteMoE/Mixtral use num_local_experts, DeepSeek-V2 uses
+    # n_routed_experts. Try in order.
+    num_experts = (
+        getattr(cfg, "num_experts", None)
+        or getattr(cfg, "num_local_experts", None)
+        or getattr(cfg, "n_routed_experts", None)
+    )
+    num_experts_per_tok = (
+        getattr(cfg, "num_experts_per_tok", None)
+        or getattr(cfg, "num_active_experts", None)
+    )
+    if num_experts is None:
+        raise ValueError(
+            f"could not find expert count on {type(cfg).__name__}; "
+            f"checked num_experts / num_local_experts / n_routed_experts"
+        )
+    if num_experts_per_tok is None:
+        raise ValueError(
+            f"could not find num_experts_per_tok on {type(cfg).__name__}"
+        )
     _log(f"  arch: {type(model).__name__}")
     _log(f"  layers={num_layers} experts={num_experts} top_k={num_experts_per_tok}")
 
@@ -189,9 +208,14 @@ def main() -> int:
         json.dump(out_data, f, indent=2)
     _log(f"wrote {out_path}")
 
-    # Quick stats: per-layer top-10 activation counts
+    # Quick stats: per-layer top-5 activation counts. Pick first / mid / last
+    # layer dynamically so this works on any model depth (Qwen3-Coder-30B has
+    # 48 layers, OLMoE has 16, Granite-3.1-3b-a800m has 32, etc.).
     _log("per-layer top expert counts (sample):")
-    for li in [0, 23, 47]:
+    sample_layers = sorted({0, num_layers // 2, num_layers - 1})
+    for li in sample_layers:
+        if li not in counts:
+            continue
         sorted_idxs = counts[li].argsort(descending=True)[:5].tolist()
         sorted_vals = counts[li][sorted_idxs].tolist()
         zeros = (counts[li] == 0).sum().item()


### PR DESCRIPTION
## Summary

Two scoped fixes that enable `expert_activation_profile.py` to ingest MoE configs from four families without modification: `Qwen3MoE` / `OlmoeForCausalLM` / `GraniteMoeForCausalLM` / `DeepseekV2ForCausalLM`.

## Empirical anchor

[`continuum-ai/olmoe-1b-7b-compacted-5b`](https://huggingface.co/continuum-ai/olmoe-1b-7b-compacted-5b) v1, alloy hash `bba0a92ff0c8bebb`. The same `expert_activation_profile.py` and `cpu_expert_prune_v2.py --importance-json` scripts that produced [`continuum-ai/qwen3-coder-30b-a3b-compacted-19b-256k`](https://huggingface.co/continuum-ai/qwen3-coder-30b-a3b-compacted-19b-256k) now produce the OLMoE artifact **without any further modification**. Cross-architecture portability of §4.1.3.4 calibration-aware MoE expert importance is empirically validated at two structurally distinct MoE families.

## The within-model A/B that landed alongside this PR

OLMoE forge ran twice with identical configuration except calibration corpus:

| OLMoE-1B-7B-0924-Instruct | HumanEval | HumanEval+ | Δ vs base |
|---|---|---|---|
| Base (Q5_K_M, hardware-measured) | 40.9 | 36.6 | (anchor) |
| Student, **broad** corpus calibration | 28.0 | 26.2 | **−12.9 / −10.4** |
| Student, **code** corpus calibration | **36.0** | **31.7** | **−4.9 / −4.9** |

**+8.0 / +5.5 HumanEval swing from changing only the calibration corpus**, holding architecture / metric / prune ratio / hardware constant. The within-model A/B isolates the calibration-corpus lever from every other variable and is the empirical motivation for the §4.1.3.4.1 calibration-corpus discipline gate (continuum-side paper update separate PR).

## Combined with the cross-architecture comparison, the 13-point ceiling is now empirically anchored at three failure cells

| Run | Importance metric | Calibration corpus | Δ HumanEval |
|---|---|---|---|
| Qwen3-Coder-30B-A3B (37.5%) | router-gate-L2 (architectural) | broad | **−13.4** |
| OLMoE-1B-7B (25%) | activation-count (calibration-aware) | broad (1/6 code) | **−12.9** |
| Qwen3-Coder-30B-A3B (37.5%) | activation-count | code | −3.7 |
| OLMoE-1B-7B (25%) | activation-count | code | −4.9 |

Wrong-metric and wrong-corpus failures saturate at near-identical magnitude across different architectures, prune ratios, and active-parameter fractions. The two levers appear to be substitutable failure modes — getting either wrong is sufficient to ceiling the damage at ~13 HumanEval points.

## The two fixes in this PR

### 1. Per-layer stats display hardcoded layer indices

The end-of-script per-layer top-5 expert counts loop hardcoded `[0, 23, 47]` from the Qwen3-Coder-30B-A3B case (48 layers). OLMoE has 16 layers → `KeyError(23)` at end of run, after the JSON output had already been written successfully.

Fixed to pick first/middle/last layer dynamically:
\`\`\`python
sample_layers = sorted({0, num_layers // 2, num_layers - 1})
for li in sample_layers:
    if li not in counts:
        continue
    ...
\`\`\`

### 2. MoE field-name divergence across families

`cfg.num_experts` is the Qwen3MoE / OlmoeConfig field name. Other families use:
- `num_local_experts` — `GraniteMoeConfig`, `MixtralConfig`
- `n_routed_experts` — `DeepseekV2Config`, `DeepseekV3Config`

Patched the loader to fall back across the three known field names with explicit `ValueError` if none match, plus the analogous fallback for `num_experts_per_tok` / `num_active_experts`.

## Tested but DOES need separate adapter sprints

- ⚠️ **`ibm-granite/granite-3.1-3b-a800m-instruct`** — 40 experts, 32 layers (`GraniteMoeForCausalLM`). Field-name fallback works (config loads). Hooks fail because Granite uses `block_sparse_moe.router.layer` (not `mlp.gate`) AND fused experts via `GraniteMoeParallelExperts`. **Needs `cpu_expert_prune_v2.py` fused-experts adapter sprint.**
- ⚠️ **`deepseek-ai/DeepSeek-V2-Lite-Chat`** — 64 routed + 2 shared experts. Shared experts must be preserved bit-exact. **Needs shared-expert exclusion sprint** (the bug-class verification protocol's Check 1 from PLASTICITY-COMPACTION §4.1.3.4 catches the failure mode if not enforced).

These two adapter sprints are tracked as the next sentinel-ai work and unblock two more families when they land.

## Refs

- continuum-ai/olmoe-1b-7b-compacted-5b on HF
- continuum-ai/qwen3-coder-30b-a3b-compacted-19b-256k on HF
- sentinel-ai#166 (the first §4.1.3.4 PR — calibration-aware activation count + Qwen3-Coder-30B-A3B v1)
- continuum#TBD (PLASTICITY-COMPACTION §4.1.3.4 update with the second empirical anchor and the §4.1.3.4.1 discipline gate)